### PR TITLE
Fix message source and reserved column names

### DIFF
--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/finance/Bill.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/finance/Bill.java
@@ -24,7 +24,7 @@ public class Bill {
 
     @OneToOne
     @MapsId
-    @JoinColumn(name = "order")
+    @JoinColumn(name = "order_id")
     private Order order;
     @ManyToOne
     @JoinColumn(name = "product")

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/orders/Order.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/orders/Order.java
@@ -72,7 +72,7 @@ public class Order {
 
     @ManyToMany
     @JoinTable(name = "OrderUnits",
-            joinColumns = @JoinColumn(name = "order"),
-            inverseJoinColumns = @JoinColumn(name = "unit"))
+            joinColumns = @JoinColumn(name = "order_id"),
+            inverseJoinColumns = @JoinColumn(name = "unit_id"))
     private Set<Unit> units = new HashSet<>();
 }

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/orders/Unit.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/orders/Unit.java
@@ -17,10 +17,10 @@ public class Unit {
 	@GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    @JoinColumn(name = "product")
+    @JoinColumn(name = "product_id")
     private Product product;
     @ManyToOne
-    @JoinColumn(name = "package")
+    @JoinColumn(name = "package_id")
     private PackageEntity packageEntity;
     private String reference;
     private Boolean loosed;

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/Bug.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/Bug.java
@@ -25,7 +25,7 @@ public class Bug {
     @JoinColumn(name = "product")
     private Product product;
     @ManyToOne
-    @JoinColumn(name = "package")
+    @JoinColumn(name = "package_id")
     private PackageEntity packageEntity;
     @Column(columnDefinition = "text")
     private String source;

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/PackageEntity.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/PackageEntity.java
@@ -20,8 +20,8 @@ public class PackageEntity {
     @Id
 	@GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "index")
-    private Integer index;
+    @Column(name = "package_index")
+    private Integer packageIndex;
     private String name;
     @Column(columnDefinition = "text")
     private String description;

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/PackageStep.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/PackageStep.java
@@ -16,12 +16,12 @@ import java.time.LocalDateTime;
 public class PackageStep {
     @Id
     @ManyToOne
-    @JoinColumn(name = "package")
+    @JoinColumn(name = "package_id")
     private PackageEntity packageEntity;
 
     @Id
     @ManyToOne
-    @JoinColumn(name = "step")
+    @JoinColumn(name = "step_id")
     private Step step;
 
     @Column(name = "started_at")

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/Step.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/products/Step.java
@@ -20,6 +20,6 @@ public class Step {
     @ManyToOne
     @JoinColumn(name = "product")
     private Product product;
-    @Column(name = "index")
-    private Integer index;
+    @Column(name = "step_index")
+    private Integer stepIndex;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,8 @@ spring.datasource.password=root
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.thymeleaf.cache=false
+
+# Internationalization
+spring.messages.basename=messages_fr
+spring.web.locale=fr
+spring.web.locale-resolver=fixed


### PR DESCRIPTION
## Summary
- configure Spring to load French message bundle and use French locale
- rename JPA columns that used SQL reserved keywords to allow schema creation

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_689366054f448323b6c4cfacf759fc1c