### PR TITLE
Fix i18n message loading and MySQL reserved name issues

### DIFF
--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/customers/Customer.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/customers/Customer.java
@@ -79,7 +79,8 @@ public class Customer {
     @ManyToMany
     @JoinTable(name = "CustomerGroups",
             joinColumns = @JoinColumn(name = "customer"),
-            inverseJoinColumns = @JoinColumn(name = "group"))
+            inverseJoinColumns = @JoinColumn(name = "`group`")
+    )
     private Set<GroupEntity> groups = new HashSet<>();
 
     @ManyToMany

--- a/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/customers/GroupEntity.java
+++ b/src/main/java/fr/hattane/ilias/rtt/cpcc/entity/customers/GroupEntity.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "Groups")
+@Table(name = "`Groups`")
 public class GroupEntity {
     @Id
 	@GeneratedValue(strategy=GenerationType.IDENTITY)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,6 @@ spring.jpa.show-sql=true
 spring.thymeleaf.cache=false
 
 # Internationalization
-spring.messages.basename=messages_fr
+spring.messages.basename=messages
 spring.web.locale=fr
 spring.web.locale-resolver=fixed


### PR DESCRIPTION
## Summary
- use default `messages` bundle so `messages_fr` resources are resolved
- escape MySQL reserved `Groups` table and `group` column in customer-group mapping

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68936fb8e144832396e23dfd17e9ffeb